### PR TITLE
Fixing error getting card by query string

### DIFF
--- a/PokemonTcgSdk/Card.cs
+++ b/PokemonTcgSdk/Card.cs
@@ -28,7 +28,7 @@ namespace PokemonTcgSdk
         {
             try
             {
-                var pokemon = QueryBuilder.GetPokemonCards();
+                var pokemon = QueryBuilder.GetPokemonCards(query);
                 return pokemon ?? new Pokemon {Errors = new List<string> {"Not Found"}};
             }
             catch (Exception ex)

--- a/PokemonTest/PokemonTest.cs
+++ b/PokemonTest/PokemonTest.cs
@@ -1,14 +1,14 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using PokemonTcgSdk;
+﻿using PokemonTcgSdk;
 using PokemonTcgSdk.Models;
 using System.Collections.Generic;
+using NUnit.Framework;
 
 namespace PokemonTest
 {
-    [TestClass]
+    [TestFixture]
     public class PokemonTest
     {
-        [TestMethod]
+        [Test]
         public void GetAllCards()
         {
             var cards = Card.All();
@@ -17,10 +17,10 @@ namespace PokemonTest
 
             Assert.IsTrue(cards.Count > 8000);
             Assert.IsFalse(string.IsNullOrWhiteSpace(name));
-            Assert.IsInstanceOfType(firstCard, typeof(PokemonCard));
+            Assert.IsInstanceOf<PokemonCard>(firstCard);// IsInstanceOfType(firstCard, typeof(PokemonCard));
         }
 
-        [TestMethod]
+        [Test]
         public void FindPokemonCard()
         {
             var card = Card.Find<Pokemon>("base4-4");
@@ -30,46 +30,60 @@ namespace PokemonTest
             Assert.IsNotNull(card);
         }
 
-        [TestMethod]
+        [Test]
         public void GetPokemonCards()
         {
             var cards = Card.Get<Pokemon>();
             var name = cards.Cards[0].Name;
 
             Assert.IsNotNull(cards);
-            Assert.IsInstanceOfType(cards, typeof(Pokemon));
+            Assert.IsInstanceOf<Pokemon>(cards);
             Assert.IsFalse(string.IsNullOrWhiteSpace(name));
         }
 
-        [TestMethod]
-        public void GetPokemonCardsByQueryString()
+        [TestCase("name", "Charizard")]
+        [TestCase("name", "Blastoise")]
+        [TestCase("name", "Venusaur")]
+        [TestCase("set", "sm6")]
+        public void GetPokemonCardsByQueryString(string field, string value)
         {
-            Dictionary<string, string> query = new Dictionary<string, string>()
+            var query = new Dictionary<string, string>()
             {
-                { "name", "Charizard" }
+                { field, value }
             };
             var cards = Card.Get(query);
 
             Assert.IsNotNull(cards);
-            Assert.IsInstanceOfType(cards, typeof(Pokemon));
+            Assert.IsInstanceOf<Pokemon>(cards);
             foreach (var pokemonCard in cards.Cards)
             {
-                Assert.IsTrue(pokemonCard.Name.Contains("Charizard"));
+                switch (field)
+                {
+                    case "name":
+                        Assert.IsTrue(pokemonCard.Name.Contains(value));
+                        break;
+                    case "set":
+                        Assert.IsTrue(pokemonCard.Set.Contains(value));
+                        break;
+                    default:
+                        Assert.IsTrue(!string.IsNullOrWhiteSpace(pokemonCard.Id));
+                        break;
+                }
             }
         }
 
-        [TestMethod]
+        [Test]
         public void GetTrainerCards()
         {
             var cards = Card.Get<Trainer>();
             var name = cards.Cards[0].Name;
 
             Assert.IsNotNull(cards);
-            Assert.IsInstanceOfType(cards, typeof(Trainer));
+            Assert.IsInstanceOf<Trainer>(cards);
             Assert.IsFalse(string.IsNullOrWhiteSpace(name));
         }
 
-        [TestMethod]
+        [Test]
         public void GetSubTypes()
         {
             var subTypes = SubTypes.All();
@@ -78,7 +92,7 @@ namespace PokemonTest
             Assert.IsTrue(subTypes.Count > 1);
         }
 
-        [TestMethod]
+        [Test]
         public void GetSuperTypes()
         {
             var superTypes = SuperTypes.All();
@@ -87,7 +101,7 @@ namespace PokemonTest
             Assert.IsTrue(superTypes.Count > 1);
         }
 
-        [TestMethod]
+        [Test]
         public void GetTypes()
         {
             var types = Types.All();
@@ -96,7 +110,7 @@ namespace PokemonTest
             Assert.IsTrue(types.Count > 1);
         }
 
-        [TestMethod]
+        [Test]
         public void GetSets()
         {
             var sets = Sets.All();
@@ -105,7 +119,7 @@ namespace PokemonTest
             Assert.IsTrue(sets.Count > 1);
         }
 
-        [TestMethod]
+        [Test]
         public void FindSets()
         {
             var query = new Dictionary<string, string>
@@ -121,7 +135,7 @@ namespace PokemonTest
             Assert.IsTrue(sets.Count >= 1);
         }
 
-        [TestMethod]
+        [Test]
         public void FindSet()
         {
             var query = new Dictionary<string, string>
@@ -137,7 +151,7 @@ namespace PokemonTest
             Assert.IsTrue(sets.Count >= 1);
         }
 
-        [TestMethod]
+        [Test]
         public void AllCardsBySeries()
         {
             var query = new Dictionary<string, string>
@@ -153,7 +167,7 @@ namespace PokemonTest
             Assert.IsTrue(cards.Count >= 1);
         }
 
-        [TestMethod]
+        [Test]
         public void AllCardsByStandardLegal()
         {
             var query = new Dictionary<string, string>

--- a/PokemonTest/PokemonTest.cs
+++ b/PokemonTest/PokemonTest.cs
@@ -42,6 +42,23 @@ namespace PokemonTest
         }
 
         [TestMethod]
+        public void GetPokemonCardsByQueryString()
+        {
+            Dictionary<string, string> query = new Dictionary<string, string>()
+            {
+                { "name", "Charizard" }
+            };
+            var cards = Card.Get(query);
+
+            Assert.IsNotNull(cards);
+            Assert.IsInstanceOfType(cards, typeof(Pokemon));
+            foreach (var pokemonCard in cards.Cards)
+            {
+                Assert.IsTrue(pokemonCard.Name.Contains("Charizard"));
+            }
+        }
+
+        [TestMethod]
         public void GetTrainerCards()
         {
             var cards = Card.Get<Trainer>();

--- a/PokemonTest/PokemonTest.csproj
+++ b/PokemonTest/PokemonTest.csproj
@@ -35,6 +35,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -58,6 +62,9 @@
       <Project>{bd97f285-4fb2-419e-a967-732494271e34}</Project>
       <Name>PokemonTcgSdk</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/PokemonTest/packages.config
+++ b/PokemonTest/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.5.0" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Fixing an error found following the documentation.

If you run the following code, it doesn't apply the filters:
```
Dictionary<string, string> query = new Dictionary<string, string>()
{
    { "name", "Charizard" },
    { "set", "Base" }
};

var cards = Card.Get(query);
cards.Cards;
```

In addition, I have added a test to make sure it works in the future.