### PR TITLE
Added NET Core as a target framework

### DIFF
--- a/PokemonTcgSdk/PokemonTcgSdk.csproj
+++ b/PokemonTcgSdk/PokemonTcgSdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Hello,

This is a small change that adds NET Core 2.0 as a target framework. The project works without issues on NET Core apps, but shows a warning message indicating that it's not meant for NET Core because it's not listed in the .csproj under TargetFrameworks.

Thanks.