### PR TITLE
added orderBy + rename skip to page

### DIFF
--- a/PokemonTcgSdk.Standard.Tests/PokemonTests.cs
+++ b/PokemonTcgSdk.Standard.Tests/PokemonTests.cs
@@ -19,6 +19,19 @@
     public class PokemonTests
     {
         [Test]
+        public async Task GetSet_ApiResourcePageAsync_Ordering()
+        {
+            // assemble
+            var httpclient = new HttpClient();
+            var pokeClient = new PokemonApiClient(httpclient);
+
+            // act
+            var page = await pokeClient.GetApiResourceAsync<Set>(orderBy: "-total");
+
+            // assert
+            Assert.That(page.Results.First().Total >= page.Results[1].Total,Is.True);
+        }
+        [Test]
         public async Task GetApiResourcePageAsync()
         {
             // assemble
@@ -44,11 +57,26 @@
             var pokeClient = new PokemonApiClient(httpclient);
 
             // act
-            var page = await pokeClient.GetApiResourceAsync<Set>(take: 10, skip: 2);
+            var page = await pokeClient.GetApiResourceAsync<Set>(take: 10, page: 2);
 
             // assert
             Assert.That(page.Page, Is.EqualTo("2").NoClip);
             Assert.That(page.PageSize, Is.EqualTo("10").NoClip);
+        }
+
+        [Test]
+        public async Task GetSet_ApiResourcePageAsync_OrderingAndPagination()
+        {
+            // assemble
+            var httpclient = new HttpClient();
+            var pokeClient = new PokemonApiClient(httpclient);
+
+            // act
+            var page = await pokeClient.GetApiResourceAsync<Card>(take: 20, page:1, orderBy: "-convertedRetreatCost");
+
+            // assert
+            Assert.That(page.Results.First().ConvertedRetreatCost >= page.Results[1].ConvertedRetreatCost, Is.True);
+            Assert.That(page.Count, Is.EqualTo(20));
         }
 
         [Test]
@@ -95,7 +123,7 @@
             var pokeClient = new PokemonApiClient(httpclient);
 
             // act
-            var page = await pokeClient.GetApiResourceAsync<Card>(take: 10, skip: 2);
+            var page = await pokeClient.GetApiResourceAsync<Card>(take: 10, page: 2);
 
             // assert
             Assert.That(page.Page, Is.EqualTo("2").NoClip);
@@ -130,7 +158,7 @@
             var pokeClient = new PokemonApiClient(httpclient);
 
             // act
-            var page = await pokeClient.GetApiResourceAsync<PokemonCard>(take: 10, skip: 2);
+            var page = await pokeClient.GetApiResourceAsync<PokemonCard>(take: 10, page: 2);
 
             // assert
             Assert.That(page.Page, Is.EqualTo("2").NoClip);
@@ -168,7 +196,7 @@
             var pokeClient = new PokemonApiClient(httpclient);
 
             // act
-            var page = await pokeClient.GetApiResourceAsync<TrainerCard>(take: 10, skip: 2);
+            var page = await pokeClient.GetApiResourceAsync<TrainerCard>(take: 10, page: 2);
 
             // assert
             Assert.That(page.Page, Is.EqualTo("2").NoClip);
@@ -201,7 +229,7 @@
             var pokeClient = new PokemonApiClient(httpclient);
 
             // act
-            var page = await pokeClient.GetApiResourceAsync<EnergyCard>(take: 10, skip: 2);
+            var page = await pokeClient.GetApiResourceAsync<EnergyCard>(take: 10, page: 2);
 
             // assert
             Assert.That(page.Page, Is.EqualTo("2").NoClip);
@@ -338,12 +366,12 @@
 
             // act
             pokeClient.ClearCache();
-            var page = await pokeClient.GetApiResourceAsync<PokemonCard>(take: 10, skip: 2);
+            var page = await pokeClient.GetApiResourceAsync<PokemonCard>(take: 10, page: 2);
             // assert
             Assert.That(page.FromCache, Is.False);
 
             // act
-            var cache = await pokeClient.GetApiResourceAsync<PokemonCard>(take: 10, skip: 2);
+            var cache = await pokeClient.GetApiResourceAsync<PokemonCard>(take: 10, page: 2);
             // assert
             Assert.That(cache.FromCache, Is.True);
         }

--- a/PokemonTcgSdk.Standard/Infrastructure/HttpClients/PokemonApiClient.cs
+++ b/PokemonTcgSdk.Standard/Infrastructure/HttpClients/PokemonApiClient.cs
@@ -135,18 +135,48 @@
         }
 
         /// <summary>
+        /// Gets a single page of unnamed resource data
+        /// </summary>
+        /// <typeparam name="T">The type of resource</typeparam>
+        /// <param name="orderBy">The ordering parameter to pass for the request.</param>
+        /// <param name="cancellationToken">Cancellation token for the request; not utilitized if data has been cached</param>
+        /// <returns>The paged resource object</returns>
+        public Task<ApiResourceList<T>> GetApiResourceAsync<T>(string orderBy, CancellationToken cancellationToken = default)
+            where T : ApiResource
+        {
+            string url = GetApiEndpointString<T>();
+            return InternalGetApiResourcePageAsync<T>(AddPaginationParamsToUrl(url, orderBy: orderBy), cancellationToken);
+        }
+
+        /// <summary>
         /// Gets the specified page of unnamed resource data
         /// </summary>
         /// <typeparam name="T">The type of resource</typeparam>
         /// <param name="take">The number of cards to return</param>
-        /// <param name="skip">Page offset/skip</param>
+        /// <param name="page">page to get, as this is not handled as an offet at all</param>
         /// <param name="cancellationToken">Cancellation token for the request; not utilitized if data has been cached</param>
         /// <returns>The paged resource object</returns>
-        public Task<ApiResourceList<T>> GetApiResourceAsync<T>(int take, int skip, CancellationToken cancellationToken = default)
+        public Task<ApiResourceList<T>> GetApiResourceAsync<T>(int take, int page, CancellationToken cancellationToken = default)
             where T : ApiResource
         {
             string url = GetApiEndpointString<T>();
-            return InternalGetApiResourcePageAsync<T>(AddPaginationParamsToUrl(url, take, skip), cancellationToken);
+            return InternalGetApiResourcePageAsync<T>(AddPaginationParamsToUrl(url, take, page), cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the specified page of unnamed resource data
+        /// </summary>
+        /// <typeparam name="T">The type of resource</typeparam>
+        /// <param name="take">The number of cards to return</param>
+        /// <param name="page">page to get, as this is not handled as an offet at all</param>
+        /// <param name="orderBy">The ordering parameter to pass for the request.</param>
+        /// <param name="cancellationToken">Cancellation token for the request; not utilitized if data has been cached</param>
+        /// <returns>The paged resource object</returns>
+        public Task<ApiResourceList<T>> GetApiResourceAsync<T>(int take, int page, string orderBy, CancellationToken cancellationToken = default)
+            where T : ApiResource
+        {
+            string url = GetApiEndpointString<T>();
+            return InternalGetApiResourcePageAsync<T>(AddPaginationParamsToUrl(url, take, page, orderBy), cancellationToken);
         }
 
         /// <summary>
@@ -167,16 +197,49 @@
         /// Gets the specified page of unnamed resource data
         /// </summary>
         /// <typeparam name="T">The type of resource</typeparam>
-        /// <param name="take">The number of cards to return</param>
-        /// <param name="skip">Page offset/skip</param>
         /// <param name="filters">Dictionary of filters based on data fields. e.g name=base </param>
+        /// <param name="orderBy">The ordering parameter to pass for the request.</param>
         /// <param name="cancellationToken">Cancellation token for the request; not utilitized if data has been cached</param>
         /// <returns>The paged resource object</returns>
-        public Task<ApiResourceList<T>> GetApiResourceAsync<T>(int take , int skip, IDictionary<string, string> filters, CancellationToken cancellationToken = default)
+        public Task<ApiResourceList<T>> GetApiResourceAsync<T>(IDictionary<string, string> filters, string orderBy, CancellationToken cancellationToken = default)
             where T : ApiResource
         {
             string url = GetApiEndpointString<T>();
-            return InternalGetApiResourcePageAsync<T>(AddQueryFilterParamsToUrl(url, filters, take, skip), cancellationToken);
+            return InternalGetApiResourcePageAsync<T>(AddQueryFilterParamsToUrl(url, filters, orderBy: orderBy), cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the specified page of unnamed resource data
+        /// </summary>
+        /// <typeparam name="T">The type of resource</typeparam>
+        /// <param name="take">The number of cards to return</param>
+        /// <param name="page">page to get, as this is not handled as an offet at all</param>
+        /// <param name="filters">Dictionary of filters based on data fields. e.g name=base </param>
+        /// <param name="cancellationToken">Cancellation token for the request; not utilitized if data has been cached</param>
+        /// <returns>The paged resource object</returns>
+        public Task<ApiResourceList<T>> GetApiResourceAsync<T>(int take , int page, IDictionary<string, string> filters, CancellationToken cancellationToken = default)
+            where T : ApiResource
+        {
+            string url = GetApiEndpointString<T>();
+            return InternalGetApiResourcePageAsync<T>(AddQueryFilterParamsToUrl(url, filters, take, page), cancellationToken);
+        }
+
+
+        /// <summary>
+        /// Gets the specified page of unnamed resource data
+        /// </summary>
+        /// <typeparam name="T">The type of resource</typeparam>
+        /// <param name="take">The number of cards to return</param>
+        /// <param name="page">page to get, as this is not handled as an offet at all</param>
+        /// <param name="filters">Dictionary of filters based on data fields. e.g name=base </param>
+        /// <param name="orderBy">The ordering parameter to pass for the request.</param>
+        /// <param name="cancellationToken">Cancellation token for the request; not utilitized if data has been cached</param>
+        /// <returns>The paged resource object</returns>
+        public Task<ApiResourceList<T>> GetApiResourceAsync<T>(int take, int page, IDictionary<string, string> filters, string orderBy, CancellationToken cancellationToken = default)
+            where T : ApiResource
+        {
+            string url = GetApiEndpointString<T>();
+            return InternalGetApiResourcePageAsync<T>(AddQueryFilterParamsToUrl(url, filters, take, page, orderBy), cancellationToken);
         }
 
         private async Task<ApiResourceList<T>> InternalGetApiResourcePageAsync<T>(string url, CancellationToken cancellationToken)
@@ -225,7 +288,7 @@
             return serializer.Deserialize<T>(reader);
         }
 
-        private static string AddPaginationParamsToUrl(string uri, int? pageSize = null, int? page = null)
+        private static string AddPaginationParamsToUrl(string uri, int? pageSize = null, int? page = null, string? orderBy = null)
         {
             var queryParameters = new Dictionary<string, string>();
 
@@ -239,12 +302,17 @@
             if (page.HasValue)
             {
                 queryParameters.Add(nameof(page), page.Value.ToString());
+            }
+
+            if (!string.IsNullOrEmpty(orderBy))
+            {
+                queryParameters.Add(nameof(orderBy), orderBy);
             }
 
             return QueryHelpers.AddQueryString(uri, queryParameters);
         }
 
-        private static string AddQueryFilterParamsToUrl(string uri, IDictionary<string, string> filterQuery, int? pageSize = null, int? page = null)
+        private static string AddQueryFilterParamsToUrl(string uri, IDictionary<string, string> filterQuery, int? pageSize = null, int? page = null, string? orderBy = null)
         {
             var queryParameters = new Dictionary<string, string>();
 
@@ -258,6 +326,11 @@
             if (page.HasValue)
             {
                 queryParameters.Add(nameof(page), page.Value.ToString());
+            }
+
+            if (!string.IsNullOrEmpty(orderBy))
+            {
+                queryParameters.Add(nameof(orderBy), orderBy);
             }
 
             return QueryHelpers.AddQueryFiltersString(uri, queryParameters, filterQuery);


### PR DESCRIPTION
Order by is not allowed via a parameter passed to the method.

Skip has been renamed to page, as a usage of skip=0 threw an exception (it is used as a page, not a skip)