### PR TITLE
#47 Filter Ordering Extensions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,56 @@
+name: CI - Build to Nuget
+
+on:
+  create:
+    branches: 
+      - release/**
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+    
+jobs:
+  build:
+
+    env:
+      BUILD_CONFIG: 'Release'
+      SOLUTION: 'PokemonTcgSdk.sln'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Get Build Version
+      run: |
+        Import-Module .\build\GetBuildVersion.psm1
+        Write-Host $Env:GITHUB_REF
+        $version = GetBuildVersion -VersionString $Env:GITHUB_REF
+        echo "BUILD_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+      shell: pwsh
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1
+      with:
+        nuget-version: '6.x'
+        
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.x
+
+    - name: Restore dependencies
+      run: nuget restore $SOLUTION
+
+    - name: Build
+      run: dotnet build $SOLUTION --configuration $BUILD_CONFIG -p:Version=$BUILD_VERSION --no-restore
+
+    - name: Run tests
+      #run: dotnet test /p:Configuration=$env:BUILD_CONFIG --no-restore --no-build --verbosity normal
+      run: dotnet test -c Release --no-build --verbosity normal --filter "Category!=LongRunning"
+      
+    - name: Publish
+      if: startsWith(github.ref, 'refs/heads/release')
+      run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}

--- a/PokemonTcgSdk.Standard.Tests/FilterTests.cs
+++ b/PokemonTcgSdk.Standard.Tests/FilterTests.cs
@@ -1,13 +1,15 @@
 ﻿namespace PokemonTcgSdk.Standard.Tests;
 
+using Features.FilterBuilder.Base;
+using Features.FilterBuilder.Ordering;
 using Features.FilterBuilder.Pokemon;
 using Features.FilterBuilder.Set;
+using Features.FilterBuilder.Trainer;
 using Infrastructure.HttpClients.CommonModels;
 using NUnit.Framework;
 
 public class FilterTests
 {
-
     [Test]
     public void SetFilters_ReturnPopulatedDictionary()
     {
@@ -150,6 +152,151 @@ public class FilterTests
         // act
         var filterBuilder = PokemonFilterBuilder.CreatePokemonFilter().HasAncientTrait().HasAncientTrait().HasAncientTrait();
 
+
+        // assert
+        Assert.That(filterBuilder, Is.EqualTo(dicObj));
+    }
+
+    [Test]
+    public void PokemonFilter_OrderBy()
+    {
+        // assemble
+        var dicObj = new Dictionary<string, string>
+        {
+            {"name", "Darkrai"},
+            {"orderby", "hp"},
+        };
+
+        // act
+        var filterBuilder = PokemonFilterBuilder.CreatePokemonFilter().AddName("Darkrai").OrderBy("hp");
+        var dictionary = new Dictionary<string, string>(filterBuilder);
+
+        // assert
+        Assert.That(dictionary, Is.EqualTo(dicObj));
+    }
+
+    [Test]
+    public void PokemonFilter_OrderByDescending()
+    {
+        // assemble
+        var dicObj = new Dictionary<string, string>
+        {
+            {"name", "Darkrai"},
+            {"orderby", "-hp"},
+        };
+
+        // act
+        var filterBuilder = PokemonFilterBuilder.CreatePokemonFilter().AddName("Darkrai").OrderBy("hp", Ordering.Descending);
+        var dictionary = new Dictionary<string, string>(filterBuilder);
+
+        // assert
+        Assert.That(dictionary, Is.EqualTo(dicObj));
+    }
+
+    [Test]
+    public void PokemonFilter_OrderBy_ThenBy()
+    {
+        // assemble
+        var dicObj = new Dictionary<string, string>
+        {
+            {"name", "Darkrai"},
+            {"orderby", "hp"},
+            {"thenby", "id"},
+        };
+
+        // act
+        var filterBuilder = PokemonFilterBuilder.CreatePokemonFilter().AddName("Darkrai").OrderBy("hp").ThenBy("id");
+        var dictionary = new Dictionary<string, string>(filterBuilder);
+
+        // assert
+        Assert.That(dictionary, Is.EqualTo(dicObj));
+    }
+
+    [Test]
+    public void PokemonFilter_OrderBy_ThenByDescending()
+    {
+        // assemble
+        var dicObj = new Dictionary<string, string>
+        {
+            {"name", "Darkrai"},
+            {"orderby", "hp"},
+            {"thenby", "-id"},
+        };
+
+        // act
+        var filterBuilder = PokemonFilterBuilder.CreatePokemonFilter().AddName("Darkrai").OrderBy("hp").ThenBy("id", Ordering.Descending);
+        var dictionary = new Dictionary<string, string>(filterBuilder);
+
+        // assert
+        Assert.That(dictionary, Is.EqualTo(dicObj));
+    }
+
+    [Test]
+    public void PokemonFilter_OrderBy_TwoThenBy()
+    {
+        // assemble
+        var dicObj = new Dictionary<string, string>
+        {
+            {"name", "Darkrai"},
+            {"orderby", "hp"},
+            {"thenby", "id,supertype"},
+        };
+
+        // act
+        var filterBuilder = PokemonFilterBuilder.CreatePokemonFilter().AddName("Darkrai").OrderBy("hp").ThenBy("id").ThenBy("supertype");
+        var dictionary = new Dictionary<string, string>(filterBuilder);
+
+        // assert
+        Assert.That(dictionary, Is.EqualTo(dicObj));
+    }
+
+    [Test]
+    public void TrainerFilter_Name()
+    {
+        // assemble
+        var dicObj = new Dictionary<string, string>
+        {
+            {"name", "Misty's Favor"}
+        };
+
+        // act
+        var filterBuilder = TrainerFilterBuilder.CreateTrainerFilter().AddName("Misty's Favor");
+
+        // assert
+        Assert.That(filterBuilder, Is.EqualTo(dicObj));
+    }
+
+
+    [Test]
+    public void TrainerFilter_Name_OrderBy()
+    {
+        // assemble
+        var dicObj = new Dictionary<string, string>
+        {
+            {"name", "Misty's Favor"},
+            {"orderby", "number"}
+        };
+
+        // act
+        var filterBuilder = TrainerFilterBuilder.CreateTrainerFilter().AddName("Misty's Favor").OrderBy("number");
+
+        // assert
+        Assert.That(filterBuilder, Is.EqualTo(dicObj));
+    }
+
+    [Test]
+    public void TrainerFilter_Name_OrderByThenBy()
+    {
+        // assemble
+        var dicObj = new Dictionary<string, string>
+        {
+            {"name", "Misty's Favor"},
+            {"orderby", "number"},
+            {"thenby", "artist"},
+        };
+
+        // act
+        var filterBuilder = TrainerFilterBuilder.CreateTrainerFilter().AddName("Misty's Favor").OrderBy("number").ThenBy("artist");
 
         // assert
         Assert.That(filterBuilder, Is.EqualTo(dicObj));

--- a/PokemonTcgSdk.Standard.Tests/PokemonTests.cs
+++ b/PokemonTcgSdk.Standard.Tests/PokemonTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace PokemonTcgSdk.Standard.Tests
 {
+    using Features.FilterBuilder.Base;
     using Features.FilterBuilder.Energy;
+    using Features.FilterBuilder.Ordering;
     using Features.FilterBuilder.Pokemon;
     using Features.FilterBuilder.Set;
     using Features.FilterBuilder.Trainer;
@@ -144,10 +146,9 @@
             var httpclient = new HttpClient();
             var pokeClient = new PokemonApiClient(httpclient);
 
-            var filter = new PokemonFilterCollection<string, string>()
-                .AddName("Darkrai");
+            var filter = new PokemonFilterCollection<string, string>().AddName("Darkrai");
             filter.Add("legalities.standard", "legal");
-
+            //filter.OrderBy("hp", ordering: Ordering.Descending).ThenBy("id");
 
             // act
             var page = await pokeClient.GetApiResourceAsync<PokemonCard>(10, 1, filter);
@@ -182,6 +183,7 @@
             var httpclient = new HttpClient();
             var pokeClient = new PokemonApiClient(httpclient);
             var filter = new TrainerFilterCollection<string, string>().AddName("Tropical Wind");
+            //filter.OrderBy("id");
             // act
             var page = await pokeClient.GetApiResourceAsync<TrainerCard>(2, 2, filter);
 
@@ -480,6 +482,21 @@
             Assert.That(page.Results.Any(x => x.Name == "Charizard"));
             //Not using exact matching so this Assert fails
             //Assert.That(page.Results.Select(item => item.Name), Is.All.EqualTo("Darkai").Or.EqualTo("Pikachu"));
+        }
+
+        [Test]
+        public async Task GetPokemon_Resource_ApiResourcePageAsyncPageZero()
+        {
+            // assemble
+            var httpclient = new HttpClient();
+            var pokeClient = new PokemonApiClient(httpclient);
+
+            // act
+            var page = await pokeClient.GetApiResourceAsync<PokemonCard>(take: 10, skip: 0);
+
+            // assert
+            Assert.That(page.Page, Is.EqualTo("1").NoClip);
+            Assert.That(page.PageSize, Is.EqualTo("10").NoClip);
         }
     }
 }

--- a/PokemonTcgSdk.Standard/Features/FilterBuilder/Base/BaseFilter.cs
+++ b/PokemonTcgSdk.Standard/Features/FilterBuilder/Base/BaseFilter.cs
@@ -1,0 +1,42 @@
+﻿namespace PokemonTcgSdk.Standard.Features.FilterBuilder.Base;
+
+using Ordering;
+
+public static class BaseFilter
+{
+    private const string OrderByKey = "orderby";
+    private const string ThenByKey = "thenby";
+
+    public static TCollection AddOrUpdate<TCollection>(TCollection dictionary, string key, string value) 
+        where TCollection : BaseFilterCollection<string, string>
+    {
+        if (dictionary.TryGetValue(key, out var oldValue))
+        {
+            oldValue = $"{oldValue},{value}";
+            dictionary[key] = oldValue;
+            return dictionary;
+        }
+
+        dictionary.Add(key, value);
+        return dictionary;
+    }
+
+    public static OrderedCardFilterCollection<TCollection, string, string> ThenBy<TCollection>(this OrderedCardFilterCollection<TCollection, string, string> dictionary, string value, Ordering ordering = 0)
+        where TCollection : BaseFilterCollection<string, string>
+    {
+        if (ordering == Ordering.Descending)
+        {
+            value = $"-{value}";
+        }
+
+        if (dictionary.TryGetOrderingValue(ThenByKey, out var existingThenBy))
+        {
+            dictionary.SetOrderingValue(ThenByKey, $"{existingThenBy},{value}");
+        }
+        else
+        {
+            dictionary.SetOrderingValue(ThenByKey, value);
+        }
+        return dictionary;
+    }
+}

--- a/PokemonTcgSdk.Standard/Features/FilterBuilder/Base/BaseFilterCollection.cs
+++ b/PokemonTcgSdk.Standard/Features/FilterBuilder/Base/BaseFilterCollection.cs
@@ -1,0 +1,80 @@
+﻿namespace PokemonTcgSdk.Standard.Features.FilterBuilder.Base;
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+using Ordering;
+
+public abstract class BaseFilterCollection<TKey, TValue> : IFilterCollection<TKey, TValue>
+{
+    private readonly Dictionary<TKey, TValue> _dictionary = new Dictionary<TKey, TValue>();
+
+    public TValue this[TKey key]
+    {
+        get => _dictionary[key];
+        set => _dictionary[key] = value;
+    }
+
+    public ICollection<TKey> Keys => _dictionary.Keys;
+    public ICollection<TValue> Values => _dictionary.Values;
+    public int Count => _dictionary.Count;
+    public bool IsReadOnly => false;
+
+    public void Add(TKey key, TValue value) => _dictionary.Add(key, value);
+    public void Add(KeyValuePair<TKey, TValue> item) => _dictionary.Add(item.Key, item.Value);
+    public void Clear() => _dictionary.Clear();
+    public bool Contains(KeyValuePair<TKey, TValue> item) => _dictionary.Contains(item);
+    public bool ContainsKey(TKey key) => _dictionary.ContainsKey(key);
+    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        => ((IDictionary<TKey, TValue>)_dictionary).CopyTo(array, arrayIndex);
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _dictionary.GetEnumerator();
+    public bool Remove(TKey key) => _dictionary.Remove(key);
+    public bool Remove(KeyValuePair<TKey, TValue> item)
+        => ((IDictionary<TKey, TValue>)_dictionary).Remove(item);
+    public bool TryGetValue(TKey key, out TValue value) => _dictionary.TryGetValue(key, out value);
+    IEnumerator IEnumerable.GetEnumerator() => _dictionary.GetEnumerator();
+
+    /// <summary>
+    /// Orders the collection by the specified value and direction.
+    /// </summary>
+    /// <param name="value">The value to order by.</param>
+    /// <param name="ordering">Optional. The ordering direction. Default is ascending (0). Use Ordering.Descending for descending order.</param>
+    /// <returns>A new <see cref="OrderedCardFilterCollection{TCollection, TKey, TValue}"/> containing the ordered collection.</returns>
+    /// <remarks>
+    /// Once OrderBy is called, subsequent ordering must use ThenBy. Multiple OrderBy calls are prevented at compile time.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var filter = new PokemonFilterCollection&lt;string, string&gt;()
+    ///     .AddName("Darkrai")
+    ///     .OrderBy("hp", Ordering.Descending);
+    /// </code>
+    /// </example>
+    public OrderedCardFilterCollection<BaseFilterCollection<TKey, TValue>, TKey, TValue> OrderBy(TValue value, Ordering ordering = 0)
+    {
+        var typedKey = (TKey)(object)"orderby";
+        if (ordering == Ordering.Descending)
+        {
+            _dictionary[typedKey] = (TValue)(object)$"-{value}";
+        }
+        else
+        {
+            _dictionary[typedKey] = value;
+        }
+        return new OrderedCardFilterCollection<BaseFilterCollection<TKey, TValue>, TKey, TValue>(this);
+    }
+
+    protected internal bool TryGetOrderingValue(string key, out TValue value)
+    {
+        value = default;
+        var typedKey = (TKey)(object)key;
+        return _dictionary.TryGetValue(typedKey, out value);
+    }
+
+    protected internal void SetOrderingValue(string key, TValue value)
+    {
+        var typedKey = (TKey)(object)key;
+        _dictionary[typedKey] = value;
+    }
+}

--- a/PokemonTcgSdk.Standard/Features/FilterBuilder/Energy/EnergyFilterCollection.cs
+++ b/PokemonTcgSdk.Standard/Features/FilterBuilder/Energy/EnergyFilterCollection.cs
@@ -1,79 +1,13 @@
 ﻿namespace PokemonTcgSdk.Standard.Features.FilterBuilder.Energy;
 
-using System.Collections;
-using System.Collections.Generic;
+using Base;
 
 /// <summary>
-/// Our own internal dictionary like collection.
+/// Represents a collection of energy card filters with ordering capabilities.
 /// </summary>
-public class EnergyFilterCollection<TKey, TValue> : IDictionary<TKey, TValue>
+/// <typeparam name="TKey">The type of keys in the collection.</typeparam>
+/// <typeparam name="TValue">The type of values in the collection.</typeparam>
+public class EnergyFilterCollection<TKey, TValue> : BaseFilterCollection<TKey, TValue>
 {
-    private readonly IDictionary<TKey, TValue> _innerDictionary
-        = new Dictionary<TKey, TValue>();
-
-    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
-    {
-        return _innerDictionary.GetEnumerator();
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
-
-    public virtual void Add(KeyValuePair<TKey, TValue> item)
-    {
-        _innerDictionary.Add(item);
-    }
-
-    public void Clear()
-    {
-        _innerDictionary.Clear();
-    }
-
-    public bool Contains(KeyValuePair<TKey, TValue> item)
-    {
-        return _innerDictionary.Contains(item);
-    }
-
-    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
-    {
-        _innerDictionary.CopyTo(array, arrayIndex);
-    }
-
-    public bool Remove(KeyValuePair<TKey, TValue> item)
-    {
-        return _innerDictionary.Remove(item);
-    }
-
-    public int Count => _innerDictionary.Count;
-    public bool IsReadOnly => _innerDictionary.IsReadOnly;
-    public bool ContainsKey(TKey key)
-    {
-        return _innerDictionary.ContainsKey(key);
-    }
-
-    public virtual void Add(TKey key, TValue value)
-    {
-        _innerDictionary.Add(key, value);
-    }
-
-    public bool Remove(TKey key)
-    {
-        return _innerDictionary.Remove(key);
-    }
-
-    public bool TryGetValue(TKey key, out TValue value)
-    {
-        return _innerDictionary.TryGetValue(key, out value);
-    }
-
-    public virtual TValue this[TKey key]
-    {
-        get => _innerDictionary[key];
-        set => _innerDictionary[key] = value;
-    }
-
-    public ICollection<TKey> Keys => _innerDictionary.Keys;
-    public ICollection<TValue> Values => _innerDictionary.Values;
+    // Stubbed
 }

--- a/PokemonTcgSdk.Standard/Features/FilterBuilder/Ordering/IFilterCollection.cs
+++ b/PokemonTcgSdk.Standard/Features/FilterBuilder/Ordering/IFilterCollection.cs
@@ -1,0 +1,8 @@
+﻿namespace PokemonTcgSdk.Standard.Features.FilterBuilder.Ordering;
+
+using System.Collections.Generic;
+
+public interface IFilterCollection<TKey, TValue> : IDictionary<TKey, TValue>
+{
+    // Stubbed
+}

--- a/PokemonTcgSdk.Standard/Features/FilterBuilder/Ordering/OrderedCardFilterCollection.cs
+++ b/PokemonTcgSdk.Standard/Features/FilterBuilder/Ordering/OrderedCardFilterCollection.cs
@@ -1,0 +1,50 @@
+﻿namespace PokemonTcgSdk.Standard.Features.FilterBuilder.Ordering;
+
+using System.Collections;
+using System.Collections.Generic;
+
+using Base;
+
+public class OrderedCardFilterCollection<TCollection, TKey, TValue> : IFilterCollection<TKey, TValue>
+    where TCollection : BaseFilterCollection<TKey, TValue>
+{
+    private readonly TCollection _baseCollection;
+
+    internal OrderedCardFilterCollection(TCollection collection)
+    {
+        _baseCollection = collection;
+    }
+
+    // Implement IFilterCollection by delegating to _baseCollection
+    public TValue this[TKey key]
+    {
+        get => _baseCollection[key];
+        set => _baseCollection[key] = value;
+    }
+
+    public ICollection<TKey> Keys => _baseCollection.Keys;
+    public ICollection<TValue> Values => _baseCollection.Values;
+    public int Count => _baseCollection.Count;
+    public bool IsReadOnly => _baseCollection.IsReadOnly;
+
+    public void Add(TKey key, TValue value) => _baseCollection.Add(key, value);
+    public void Add(KeyValuePair<TKey, TValue> item) => _baseCollection.Add(item);
+    public void Clear() => _baseCollection.Clear();
+    public bool Contains(KeyValuePair<TKey, TValue> item) => _baseCollection.Contains(item);
+    public bool ContainsKey(TKey key) => _baseCollection.ContainsKey(key);
+    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) => _baseCollection.CopyTo(array, arrayIndex);
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _baseCollection.GetEnumerator();
+    public bool Remove(TKey key) => _baseCollection.Remove(key);
+    public bool Remove(KeyValuePair<TKey, TValue> item) => _baseCollection.Remove(item);
+    public bool TryGetValue(TKey key, out TValue value) => _baseCollection.TryGetValue(key, out value);
+    IEnumerator IEnumerable.GetEnumerator() => _baseCollection.GetEnumerator();
+    internal bool TryGetOrderingValue(string key, out TValue value)
+    {
+        return _baseCollection.TryGetOrderingValue(key, out value);
+    }
+
+    internal void SetOrderingValue(string key, TValue value)
+    {
+        _baseCollection.SetOrderingValue(key, value);
+    }
+}

--- a/PokemonTcgSdk.Standard/Features/FilterBuilder/Ordering/Ordering.cs
+++ b/PokemonTcgSdk.Standard/Features/FilterBuilder/Ordering/Ordering.cs
@@ -1,0 +1,7 @@
+﻿namespace PokemonTcgSdk.Standard.Features.FilterBuilder.Ordering;
+
+public enum Ordering
+{
+    Ascending = 0,
+    Descending,
+}

--- a/PokemonTcgSdk.Standard/Features/FilterBuilder/Pokemon/PokemonFilter.cs
+++ b/PokemonTcgSdk.Standard/Features/FilterBuilder/Pokemon/PokemonFilter.cs
@@ -3,6 +3,8 @@
 using System.Linq;
 using Infrastructure.HttpClients.Cards;
 using Infrastructure.HttpClients.CommonModels;
+using Ordering;
+using PokemonTcgSdk.Standard.Features.FilterBuilder.Base;
 
 public static class PokemonFilter
 {
@@ -18,11 +20,17 @@ public static class PokemonFilter
     }
 
     /// <summary>
-    /// Extension method. Will add new name filter. If name filter exists
-    /// will concat and create an OR filter. e.g "Mew" or "Mewtwo"
+    /// Adds or updates a Pokemon's name filter in the collection.
     /// </summary>
-    /// <param name="dictionary"></param>
-    /// <param name="value">The name value to add</param>
+    /// <param name="dictionary">The Pokemon filter collection.</param>
+    /// <param name="value">The name value to filter by.</param>
+    /// <returns>The Pokemon filter collection with the name filter added or updated.</returns>
+    /// <example>
+    /// <code>
+    /// var filter = new PokemonFilterCollection&lt;string, string&gt;()
+    ///     .AddName("Darkrai");
+    /// </code>
+    /// </example>
     public static PokemonFilterCollection<string, string> AddName(this PokemonFilterCollection<string, string> dictionary, string value)
     {
         return AddOrUpdate(dictionary, nameof(PokemonCard.Name).ToLower(), value);
@@ -167,7 +175,6 @@ public static class PokemonFilter
 
         return AddOrUpdate(dictionary, "ancientTrait.name", value);
     }
-
 
     private static PokemonFilterCollection<string, string> AddOrUpdate(PokemonFilterCollection<string, string> dictionary, string key, string value)
     {

--- a/PokemonTcgSdk.Standard/Features/FilterBuilder/Pokemon/PokemonFilterCollection.cs
+++ b/PokemonTcgSdk.Standard/Features/FilterBuilder/Pokemon/PokemonFilterCollection.cs
@@ -1,78 +1,11 @@
 ﻿namespace PokemonTcgSdk.Standard.Features.FilterBuilder.Pokemon;
-using System.Collections;
-using System.Collections.Generic;
+
+using Base;
 
 /// <summary>
 /// Our own internal dictionary like collection.
 /// </summary>
-public class PokemonFilterCollection<TKey, TValue> : IDictionary<TKey, TValue>
+public class PokemonFilterCollection<TKey, TValue> : BaseFilterCollection<TKey, TValue>
 {
-    private readonly IDictionary<TKey, TValue> _innerDictionary
-        = new Dictionary<TKey, TValue>();
-
-    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
-    {
-        return _innerDictionary.GetEnumerator();
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
-
-    public virtual void Add(KeyValuePair<TKey, TValue> item)
-    {
-        _innerDictionary.Add(item);
-    }
-
-    public void Clear()
-    {
-        _innerDictionary.Clear();
-    }
-
-    public bool Contains(KeyValuePair<TKey, TValue> item)
-    {
-        return _innerDictionary.Contains(item);
-    }
-
-    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
-    {
-        _innerDictionary.CopyTo(array, arrayIndex);
-    }
-
-    public bool Remove(KeyValuePair<TKey, TValue> item)
-    {
-        return _innerDictionary.Remove(item);
-    }
-
-    public int Count => _innerDictionary.Count;
-    public bool IsReadOnly => _innerDictionary.IsReadOnly;
-    public bool ContainsKey(TKey key)
-    {
-        return _innerDictionary.ContainsKey(key);
-    }
-
-    public virtual void Add(TKey key, TValue value)
-    {
-        _innerDictionary.Add(key, value);
-    }
-
-    public bool Remove(TKey key)
-    {
-        return _innerDictionary.Remove(key);
-    }
-
-    public bool TryGetValue(TKey key, out TValue value)
-    {
-        return _innerDictionary.TryGetValue(key, out value);
-    }
-
-    public virtual TValue this[TKey key]
-    {
-        get => _innerDictionary[key];
-        set => _innerDictionary[key] = value;
-    }
-
-    public ICollection<TKey> Keys => _innerDictionary.Keys;
-    public ICollection<TValue> Values => _innerDictionary.Values;
+    // No need for any implementation since BaseFilterCollection already provides everything
 }

--- a/PokemonTcgSdk.Standard/Features/FilterBuilder/Trainer/TrainerFilterCollection.cs
+++ b/PokemonTcgSdk.Standard/Features/FilterBuilder/Trainer/TrainerFilterCollection.cs
@@ -1,79 +1,11 @@
 ﻿namespace PokemonTcgSdk.Standard.Features.FilterBuilder.Trainer;
 
-using System.Collections;
-using System.Collections.Generic;
+using Base;
 
 /// <summary>
 /// Our own internal dictionary like collection.
 /// </summary>
-public class TrainerFilterCollection<TKey, TValue> : IDictionary<TKey, TValue>
+public class TrainerFilterCollection<TKey, TValue> : BaseFilterCollection<TKey, TValue>
 {
-    private readonly IDictionary<TKey, TValue> _innerDictionary
-        = new Dictionary<TKey, TValue>();
-
-    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
-    {
-        return _innerDictionary.GetEnumerator();
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
-
-    public virtual void Add(KeyValuePair<TKey, TValue> item)
-    {
-        _innerDictionary.Add(item);
-    }
-
-    public void Clear()
-    {
-        _innerDictionary.Clear();
-    }
-
-    public bool Contains(KeyValuePair<TKey, TValue> item)
-    {
-        return _innerDictionary.Contains(item);
-    }
-
-    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
-    {
-        _innerDictionary.CopyTo(array, arrayIndex);
-    }
-
-    public bool Remove(KeyValuePair<TKey, TValue> item)
-    {
-        return _innerDictionary.Remove(item);
-    }
-
-    public int Count => _innerDictionary.Count;
-    public bool IsReadOnly => _innerDictionary.IsReadOnly;
-    public bool ContainsKey(TKey key)
-    {
-        return _innerDictionary.ContainsKey(key);
-    }
-
-    public virtual void Add(TKey key, TValue value)
-    {
-        _innerDictionary.Add(key, value);
-    }
-
-    public bool Remove(TKey key)
-    {
-        return _innerDictionary.Remove(key);
-    }
-
-    public bool TryGetValue(TKey key, out TValue value)
-    {
-        return _innerDictionary.TryGetValue(key, out value);
-    }
-
-    public virtual TValue this[TKey key]
-    {
-        get => _innerDictionary[key];
-        set => _innerDictionary[key] = value;
-    }
-
-    public ICollection<TKey> Keys => _innerDictionary.Keys;
-    public ICollection<TValue> Values => _innerDictionary.Values;
+    // Stubbed
 }

--- a/PokemonTcgSdk.Standard/Infrastructure/HttpClients/PokemonApiClient.cs
+++ b/PokemonTcgSdk.Standard/Infrastructure/HttpClients/PokemonApiClient.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
-    using System.Net.Http.Headers;
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
@@ -238,6 +237,8 @@
 
             if (page.HasValue)
             {
+                // Always set page to 1 if 0 so no error
+                page = page.Equals(0) ? 1 : page;
                 queryParameters.Add(nameof(page), page.Value.ToString());
             }
 
@@ -257,6 +258,8 @@
 
             if (page.HasValue)
             {
+                // Always set page to 1 if 0 so no error
+                page = page.Equals(0) ? 1 : page;
                 queryParameters.Add(nameof(page), page.Value.ToString());
             }
 

--- a/PokemonTcgSdk.Standard/Infrastructure/HttpClients/PokemonApiClient.cs
+++ b/PokemonTcgSdk.Standard/Infrastructure/HttpClients/PokemonApiClient.cs
@@ -138,7 +138,7 @@
         /// </summary>
         /// <typeparam name="T">The type of resource</typeparam>
         /// <param name="take">The number of cards to return</param>
-        /// <param name="skip">Page offset/skip</param>
+        /// <param name="skip">Page Number (default is 1)</param>
         /// <param name="cancellationToken">Cancellation token for the request; not utilitized if data has been cached</param>
         /// <returns>The paged resource object</returns>
         public Task<ApiResourceList<T>> GetApiResourceAsync<T>(int take, int skip, CancellationToken cancellationToken = default)
@@ -167,7 +167,7 @@
         /// </summary>
         /// <typeparam name="T">The type of resource</typeparam>
         /// <param name="take">The number of cards to return</param>
-        /// <param name="skip">Page offset/skip</param>
+        /// <param name="skip">Page Number (default is 1)</param>
         /// <param name="filters">Dictionary of filters based on data fields. e.g name=base </param>
         /// <param name="cancellationToken">Cancellation token for the request; not utilitized if data has been cached</param>
         /// <returns>The paged resource object</returns>

--- a/PokemonTcgSdk.Standard/PokemonTcgSdk.Standard.csproj
+++ b/PokemonTcgSdk.Standard/PokemonTcgSdk.Standard.csproj
@@ -7,7 +7,7 @@
     <Authors>Jacob Spencer</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Copyright>MIT</Copyright>
-    <Version>2.4.2</Version>
+    <Version>2.5.0</Version>
     <PackageProjectUrl>https://github.com/PokemonTCG/pokemon-tcg-sdk-csharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PokemonTCG/pokemon-tcg-sdk-csharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />

--- a/README.md
+++ b/README.md
@@ -141,7 +141,98 @@ Also for multiple matches (so OR filter) this is done by seperating with a comma
      {"evolvesfrom", "Pikachu"}
  };
 ```
-#### Using Filters
+#### Ordering Filters
+`PokemonFilterBuilder`, `EnergyFilterBuilder` and `TrainerFilterBuilder` all support fluent like OrderBy/ThenBy. Along with the ability to order ASC or DESC (ASC is default). You can only have one OrderBy, but multiple ThenBy's.
+
+Remember that OrderBy/ThenBy's are case API sensitive (camel case)
+
+```c#
+var filter = PokemonFilterBuilder.CreatePokemonFilter()
+            .AddName("Darkrai")
+            .OrderBy("hp");
+```
+Or
+```c#
+var filter = PokemonFilterBuilder.CreatePokemonFilter()
+            .AddName("Darkrai")
+            .OrderBy(nameof(PokemonCard.Hp));
+```
+Descending:
+```c#
+var filter = PokemonFilterBuilder.CreatePokemonFilter()
+            .AddName("Darkrai")
+            .OrderBy("hp", Ordering.Descending);
+```
+ThenBy:
+```c#
+var filter = PokemonFilterBuilder.CreatePokemonFilter()
+            .AddName("Darkrai")
+            .OrderBy("hp")
+            .ThenBy("id");
+```
+```c#
+var filter = PokemonFilterBuilder.CreatePokemonFilter()
+            .AddName("Darkrai")
+            .OrderBy("hp")
+            .ThenBy("id", Ordering.Descending);
+```
+
+You can also build up the OrderBy filters without using the fluent like extensions:
+
+#### ASC
+```c#
+ var filter = new Dictionary<string, string>
+ {
+     {"name", "Darkrai,Pikachu"},
+     {"subtypes", "Stage 1"},
+     {"hp", "{60 TO 120}"},
+     {"rarity", "Common"},
+     {"attacks.convertedEnergyCost", "{2 TO 4}"},
+     {"evolvesfrom", "Pikachu"},
+     {"orderby", "hp"},
+ };
+```
+```c#
+ var filter = new Dictionary<string, string>
+ {
+     {"name", "Darkrai,Pikachu"},
+     {"subtypes", "Stage 1"},
+     {"hp", "{60 TO 120}"},
+     {"rarity", "Common"},
+     {"attacks.convertedEnergyCost", "{2 TO 4}"},
+     {"evolvesfrom", "Pikachu"},
+     {"orderby", "hp"},
+     {"thenby", "id"},
+ };
+```
+#### DESC
+```c#
+ var filter = new Dictionary<string, string>
+ {
+     {"name", "Darkrai,Pikachu"},
+     {"subtypes", "Stage 1"},
+     {"hp", "{60 TO 120}"},
+     {"rarity", "Common"},
+     {"attacks.convertedEnergyCost", "{2 TO 4}"},
+     {"evolvesfrom", "Pikachu"},
+     {"orderby", "-hp"},
+ };
+```
+```c#
+ var filter = new Dictionary<string, string>
+ {
+     {"name", "Darkrai,Pikachu"},
+     {"subtypes", "Stage 1"},
+     {"hp", "{60 TO 120}"},
+     {"rarity", "Common"},
+     {"attacks.convertedEnergyCost", "{2 TO 4}"},
+     {"evolvesfrom", "Pikachu"},
+     {"orderby", "hp"},
+     {"thenby", "-id"},
+ };
+```
+
+### Using Filters
 Once you have built up the filter you can pass it into your call method. Pagination is still supported
 ```c#
 var filter = PokemonFilterBuilder.CreatePokemonFilter().AddName("Darkrai");

--- a/build/GetBuildVersion.psm1
+++ b/build/GetBuildVersion.psm1
@@ -1,0 +1,34 @@
+Function GetBuildVersion {
+    Param (
+        [string]$VersionString
+    )
+
+    # Process through regex
+    $VersionString -match "(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?(\-(?<pre>[0-9A-Za-z\-\.]+))?(\+(?<build>\d+))?" | Out-Null
+
+    if ($matches -eq $null) {
+        return "1.0.0-build"
+    }
+
+    # Extract the build metadata
+    $BuildRevision = [uint64]$matches['build']
+    # Extract the pre-release tag
+    $PreReleaseTag = [string]$matches['pre']
+    # Extract the patch
+    $Patch = [uint64]$matches['patch']
+    # Extract the minor
+    $Minor = [uint64]$matches['minor']
+    # Extract the major
+    $Major = [uint64]$matches['major']
+
+    $Version = [string]$Major + '.' + [string]$Minor + '.' + [string]$Patch;
+    if ($PreReleaseTag -ne [string]::Empty) {
+        $Version = $Version + '-' + $PreReleaseTag
+    }
+
+    if ($BuildRevision -ne 0) {
+        $Version = $Version + '.' + [string]$BuildRevision
+    }
+
+    return $Version
+}


### PR DESCRIPTION
Added fix so if skip = 0 it defaults to 1. 
Maintained skip/take so it doesn't create a breaking change.
Refactored FilterCollections to include a new BaseFilter so it can be handled generically. 
Added in OrderBy and ThenBy. 
Both support an optional enum to declare if asc or desc